### PR TITLE
Fixes RT#92227 (Moose enum warnings)

### DIFF
--- a/lib/AnyEvent/Subprocess/Types.pm
+++ b/lib/AnyEvent/Subprocess/Types.pm
@@ -36,7 +36,7 @@ coerce SubprocessCode, from ArrayRef[Str], via {
 subtype CodeList, as ArrayRef[CodeRef];
 coerce CodeList, from CodeRef, via { [$_] };
 
-enum WhenToCallBack, qw/Readable Line/;
+enum WhenToCallBack, [qw/Readable Line/];
 
 1;
 


### PR DESCRIPTION
Fixes https://rt.cpan.org/Ticket/Display.html?id=92227

The new Moose update change the way enum should be called and calling it the old way generates warnings.
