### PR TITLE
Fix Dist::Zilla test prerequisites declaration

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,5 +5,5 @@ Moose = 1.15
 Event::Join = 0.05
 JSON = 2
 
-[Prereqs/Test]
+[Prereqs/TestRequires]
 EV = 4.0


### PR DESCRIPTION
This is for the CPAN Pull Request Challenge.

The module doesn't build with a recent version of Dist::Zilla (6.008).
```
$ dzil build
[Test] No -phase or -relationship specified ...
```
This is because the test prerequisites were not properly declared and Dist::Zilla started treating this as an error at some point.

This small change makes the module build correctly with a recent version of Dist::Zilla.