### PR TITLE
Fixes broken dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,5 +5,5 @@ Moose = 1.15
 Event::Join = 0.05
 JSON = 2
 
-[Prereqs/Test]
+[Prereqs/TestRequires]
 EV = 4.0


### PR DESCRIPTION
The `Prereqs` plugin for `Dist::Zilla` in `dist.ini` requires both a phase and a relationship to be
specified if you give a custom name. The relationship was missing for `[Prereqs/Test]` so `dzil build` threw an error *"No -phase or -relationship specified"*.