### PR TITLE
Adds a license to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,7 @@
 name = AnyEvent-Subprocess
+license = Perl_5
+copyright_holder = Jonathan Rockway
+copyright_year = 2011
 [@JROCKWAY]
 [Prereqs]
 Moose = 1.15


### PR DESCRIPTION
Due to a bug (?) in `Dist::Zilla`, if the license information was missing from `dist.ini`, it would fall back to the current user's `~/.dzil/config.ini` to get the license information. Hence, missing license information in `dist.ini` would not be detected by `dzil build` in the case the user already had a `config.ini` file.

See also https://github.com/rjbs/Dist-Zilla/issues/645