### PR TITLE
Fix "no blank line" warning.

### DIFF
--- a/lib/AnyEvent/Subprocess/Delegate.pm
+++ b/lib/AnyEvent/Subprocess/Delegate.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Delegate;
+
 # ABSTRACT: role representing a delegate
 use Moose::Role;
 

--- a/lib/AnyEvent/Subprocess/Done.pm
+++ b/lib/AnyEvent/Subprocess/Done.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Done;
+
 # ABSTRACT: represents a completed subprocess run
 use Moose;
 use namespace::autoclean;

--- a/lib/AnyEvent/Subprocess/Done/Delegate.pm
+++ b/lib/AnyEvent/Subprocess/Done/Delegate.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Done::Delegate;
+
 # ABSTRACT: role that delegates on the Done class must implement
 use Moose::Role;
 

--- a/lib/AnyEvent/Subprocess/Done/Delegate/Handle.pm
+++ b/lib/AnyEvent/Subprocess/Done/Delegate/Handle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Done::Delegate::Handle;
+
 # ABSTRACT: store leftover wbuf/rbuf from running Handle
 use Moose;
 use namespace::autoclean;

--- a/lib/AnyEvent/Subprocess/Done/Delegate/State.pm
+++ b/lib/AnyEvent/Subprocess/Done/Delegate/State.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Done::Delegate::State;
+
 # ABSTRACT: thread state through the job/run/done lifecycle
 use Moose;
 

--- a/lib/AnyEvent/Subprocess/Done/Delegate/Timeout.pm
+++ b/lib/AnyEvent/Subprocess/Done/Delegate/Timeout.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Done::Delegate::Timeout;
+
 # ABSTRACT: done delegate for a job that can time out
 use Moose;
 use namespace::autoclean;

--- a/lib/AnyEvent/Subprocess/Easy.pm
+++ b/lib/AnyEvent/Subprocess/Easy.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Easy;
+
 # ABSTRACT: wrappers around AnyEvent::Subprocess to save typing in simple cases
 use strict;
 use warnings;

--- a/lib/AnyEvent/Subprocess/Handle.pm
+++ b/lib/AnyEvent/Subprocess/Handle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Handle;
+
 # ABSTRACT: AnyEvent::Handle subclass with some additional methods for AnyEvent::Subprocess
 use strict;
 use warnings;

--- a/lib/AnyEvent/Subprocess/Job/Delegate.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate;
+
 # ABSTRACT: role that delegates on the Job class must implement
 use Moose::Role;
 

--- a/lib/AnyEvent/Subprocess/Job/Delegate/Callback.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/Callback.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::Callback;
+
 # ABSTRACT: call callbacks for each job/run/done step
 use AnyEvent::Subprocess::Running::Delegate::Callback;
 use Moose;

--- a/lib/AnyEvent/Subprocess/Job/Delegate/CaptureHandle.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/CaptureHandle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::CaptureHandle;
+
 # ABSTRACT: capture the data that comes in via a handle
 use Moose;
 use AnyEvent::Subprocess::Running::Delegate::CaptureHandle;

--- a/lib/AnyEvent/Subprocess/Job/Delegate/CompletionCondvar.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/CompletionCondvar.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::CompletionCondvar;
+
 # ABSTRACT: provide a condvar to indicate completion
 use AnyEvent::Subprocess::Running::Delegate::CompletionCondvar;
 use Moose;

--- a/lib/AnyEvent/Subprocess/Job/Delegate/Handle.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/Handle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::Handle;
+
 # ABSTRACT: share a filehandle or socket with the child
 use AnyEvent;
 use AnyEvent::Util qw(portable_pipe portable_socketpair);

--- a/lib/AnyEvent/Subprocess/Job/Delegate/MonitorHandle.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/MonitorHandle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::MonitorHandle;
+
 # ABSTRACT: monitor a handle for input and invoke callbacks with that input
 use AnyEvent::Subprocess::Running::Delegate::MonitorHandle;
 use AnyEvent::Subprocess::Types qw(CodeList WhenToCallBack);

--- a/lib/AnyEvent/Subprocess/Job/Delegate/PrintError.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/PrintError.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::PrintError;
+
 # ABSTRACT: Print errors to a filehandle
 use Moose;
 use namespace::autoclean;

--- a/lib/AnyEvent/Subprocess/Job/Delegate/Pty.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/Pty.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::Pty;
+
 # ABSTRACT: give the child a pseudo-terminal
 use IO::Pty;
 use namespace::autoclean;

--- a/lib/AnyEvent/Subprocess/Job/Delegate/Timeout.pm
+++ b/lib/AnyEvent/Subprocess/Job/Delegate/Timeout.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Job::Delegate::Timeout;
+
 # ABSTRACT: Kill a subprocess if it takes too long
 use Moose;
 use namespace::autoclean;

--- a/lib/AnyEvent/Subprocess/Role/WithDelegates.pm
+++ b/lib/AnyEvent/Subprocess/Role/WithDelegates.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Role::WithDelegates;
+
 # ABSTRACT: paramaterized role consumed by classes that have delegates
 use MooseX::Role::Parameterized;
 

--- a/lib/AnyEvent/Subprocess/Role/WithDelegates/Manager.pm
+++ b/lib/AnyEvent/Subprocess/Role/WithDelegates/Manager.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Role::WithDelegates::Manager;
+
 # ABSTRACT: manage delegate shortcuts
 use strict;
 use warnings;

--- a/lib/AnyEvent/Subprocess/Running.pm
+++ b/lib/AnyEvent/Subprocess/Running.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running;
+
 # ABSTRACT: represents a running subprocess
 use Moose;
 use Event::Join;

--- a/lib/AnyEvent/Subprocess/Running/Delegate.pm
+++ b/lib/AnyEvent/Subprocess/Running/Delegate.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running::Delegate;
+
 # ABSTRACT: delegate on the running process class
 use Moose::Role;
 

--- a/lib/AnyEvent/Subprocess/Running/Delegate/Callback.pm
+++ b/lib/AnyEvent/Subprocess/Running/Delegate/Callback.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running::Delegate::Callback;
+
 # ABSTRACT: the C<Running> part of the Callback delegate
 use Moose;
 

--- a/lib/AnyEvent/Subprocess/Running/Delegate/CaptureHandle.pm
+++ b/lib/AnyEvent/Subprocess/Running/Delegate/CaptureHandle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running::Delegate::CaptureHandle;
+
 # ABSTRACT: Running part of the CaptureHandle delegate
 use Moose;
 use AnyEvent::Subprocess::Done::Delegate::CaptureHandle;

--- a/lib/AnyEvent/Subprocess/Running/Delegate/CompletionCondvar.pm
+++ b/lib/AnyEvent/Subprocess/Running/Delegate/CompletionCondvar.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running::Delegate::CompletionCondvar;
+
 # ABSTRACT: Running part of the CompletionCondvar delegate
 use Moose;
 use AnyEvent;

--- a/lib/AnyEvent/Subprocess/Running/Delegate/Handle.pm
+++ b/lib/AnyEvent/Subprocess/Running/Delegate/Handle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running::Delegate::Handle;
+
 # ABSTRACT: Running part of the Handle delegate
 use AnyEvent::Subprocess::Handle;
 use AnyEvent::Subprocess::Done::Delegate::Handle;

--- a/lib/AnyEvent/Subprocess/Running/Delegate/MonitorHandle.pm
+++ b/lib/AnyEvent/Subprocess/Running/Delegate/MonitorHandle.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running::Delegate::MonitorHandle;
+
 # ABSTRACT: Running part of the MonitorHandle delegate
 use Moose;
 use namespace::clean;

--- a/lib/AnyEvent/Subprocess/Running/Delegate/Timeout.pm
+++ b/lib/AnyEvent/Subprocess/Running/Delegate/Timeout.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Running::Delegate::Timeout;
+
 # ABSTRACT: Running part of Timeout delegate
 use Moose;
 use namespace::autoclean;

--- a/lib/AnyEvent/Subprocess/Types.pm
+++ b/lib/AnyEvent/Subprocess/Types.pm
@@ -1,4 +1,5 @@
 package AnyEvent::Subprocess::Types;
+
 # ABSTRACT: C<MooseX::Types> used internally
 use MooseX::Types -declare => [ qw{
     Direction


### PR DESCRIPTION
Fix warnings from `dzil build` from plugin `PkgVersion` about *"no blank line for $VERSION after package"'. This is to warn the user that `Dist::Zilla` had to insert a new line into the given file to add the version number. This causes line numbers to be off by one in the generated distribution compared to line numbers in the source file. By inserting a blank line after the package statement in the source
file this problem can be fixed (and the the warning from `dzil build` goes away).