### PR TITLE
Added missing author to dist.ini.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,5 @@
 name = AnyEvent-Subprocess
+author  = Jonathan Rockway
 [@JROCKWAY]
 [Prereqs]
 Moose = 1.15


### PR DESCRIPTION
Adds a missing `author` entry to `dist.ini`. Unless the user already has a `~/.dzil/config.ini` file with a `[%User]` section with a `name` entry, `dzil build` will croak with *"Can't locate object method "authors" via package "Dist::Zilla::Stash::User"* if there is a missing author entry in `dist.ini`.