### PR TITLE
Add a $VERSION to Subprocess.pm

### DIFF
--- a/lib/AnyEvent/Subprocess.pm
+++ b/lib/AnyEvent/Subprocess.pm
@@ -1,9 +1,8 @@
 package AnyEvent::Subprocess;
+
 # ABSTRACT: flexible, OO, asynchronous process spawning and management
 use Moose;
 with 'AnyEvent::Subprocess::Job';
-
-our $VERSION;
 
 use AnyEvent::Subprocess::DefaultDelegates;
 


### PR DESCRIPTION
The module `lib/AnyEvent/Subprocess.pm` declared `our $VERSION`, but did not assign a version number. However, this declaration of `$VERSION` made the plugin `PkgVersion` believe that it should skip this file, so no version was set for this module. Fix: By removing the `$VERSION` declaration, we can make `PkgVersion` add the correct version automatically.